### PR TITLE
Allow use in same-origin children, add Feature Policy integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,6 +225,10 @@
           origin-domain</dfn></a>
         </li>
         <li>
+          <a href="https://html.spec.whatwg.org/#allowed-to-use"><dfn>allowed
+          to use</dfn></a>
+        </li>
+        <li>
           <a href=
           "https://wicg.github.io/feature-policy/#policy-controlled-feature"><dfn>
           policy-controlled feature</dfn></a>
@@ -297,13 +301,18 @@
         <a>Navigator</a> object's <a>battery promise</a> and abort these steps.
         </li>
         <li>If this <a>Navigator</a> object's <a>relevant global object</a>'s
-        <a>associated <code>Document</code></a>'s <a>browsing context</a>'s <a>
-          active document</a>'s <a>origin</a> is not <a>same origin-domain</a>
-          with the <a>origin</a> of the <a>current settings object</a> of this
-          <a>Navigator</a> object, then reject this <a>Navigator</a> object's
-          <a>battery promise</a> with a "<a>SecurityError</a>"
-          <a>DOMException</a>, return this <a>Navigator</a> object's <a>battery
-          promise</a> and abort these steps.
+        <a>associated <code>Document</code></a> is not <a>allowed to use</a>
+        the <code>battery</code> feature, then reject this <a>Navigator</a>
+        object's <a>battery promise</a> with a "<a>SecurityError</a>"
+        <a>DOMException</a>, return this <a>Navigator</a> object's <a>battery
+        promise</a> and abort these steps.
+          <div class="note">
+            In other words, this step rejects if the <a>associated
+            <code>Document</code></a>'s <a>browsing context</a>'s <a>active
+            document</a>'s <a>origin</a> is not <a>same origin-domain</a> with
+            the <a>origin</a> of the <a>current settings object</a> of this
+            <a>Navigator</a> object.
+          </div>
         </li>
         <li>If this <a>Navigator</a> object's <a>battery promise</a> is not
         <code>null</code>, return this <a>Navigator</a> object's <a>battery
@@ -526,13 +535,11 @@
         Feature Policy integration
       </h2>
       <p data-link-for="Navigator">
-        The Battery Status API is a <a>policy-controlled feature</a>, as
-        defined by Feature Policy [[!FEATURE-POLICY]]. The <a>feature name</a>
-        for the Battery Status API is "<code>battery</code>". The <a>default
-        allowlist</a> for the Battery Status API is <code>« "self" »</code>.
-        When disabled in a document, the <code><a>getBattery</a>()</code>
-        method MUST return a <a>promise</a> which rejects with a
-        "<a>SecurityError</a>" <a>DOMException</a>.
+        The Battery Status API is a <a>policy-controlled feature</a> identified
+        by the string "<code>battery</code>". It's default allowlist is
+        <code>'self'</code>. When disabled in a document, the
+        <code><a>getBattery</a>()</code> method MUST return a <a>promise</a>
+        which rejects with a "<a>SecurityError</a>" <a>DOMException</a>.
       </p>
     </section>
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -136,7 +136,8 @@
       </h2>
       <p>
         The following concepts, terms, and interfaces are defined in [[!HTML]],
-        [[!HTML5]], [[!ECMASCRIPT]], [[!WEBIDL]], and [[!SECURE-CONTEXTS]]:
+        [[!HTML5]], [[!ECMASCRIPT]], [[!WEBIDL]], [[!SECURE-CONTEXTS]], and
+        [[!FEATURE-POLICY]]:
       </p>
       <ul>
         <li>
@@ -218,6 +219,21 @@
           <a href=
           "https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain">
           <dfn>same-origin domain</dfn></a>
+        </li>
+        <li>
+          <a href=
+          "https://wicg.github.io/feature-policy/#policy-controlled-feature"><dfn>
+          policy-controlled feature</dfn></a>
+        </li>
+        <li>
+          <a href=
+          "https://wicg.github.io/feature-policy/#feature-name"><dfn>feature
+          name</dfn></a>
+        </li>
+        <li>
+          <a href=
+          "https://wicg.github.io/feature-policy/#default-allowlist"><dfn>default
+          allowlist</dfn></a>
         </li>
       </ul>
     </section>
@@ -498,6 +514,20 @@
           </tbody>
         </table>
       </section>
+    </section>
+    <section>
+      <h2>
+        Feature Policy integration
+      </h2>
+      <p data-link-for="Navigator">
+        The Battery Status API is a <a>policy-controlled feature</a>, as
+        defined by Feature Policy [[!FEATURE-POLICY]]. The <a>feature name</a>
+        for the Battery Status API is "<code>battery</code>". The <a>default
+        allowlist</a> for the Battery Status API is <code>["self"]</code>. When
+        disabled in a document, the <code><a>getBattery</a>()</code> method
+        MUST return a <a>promise</a> which rejects with a
+        "<a>SecurityError</a>" <a>DOMException</a>.
+      </p>
     </section>
     <section class="informative">
       <h2>

--- a/index.html
+++ b/index.html
@@ -153,6 +153,9 @@
           task</a></dfn>
         </li>
         <li>
+          <code><dfn data-cite="DOM#eventtarget">EventTarget</dfn></code>
+        </li>
+        <li>
           <dfn><a href=
           "https://www.w3.org/TR/html5/webappapis.html#firing-a-simple-event-named-e">
           fires a simple event</a></dfn>

--- a/index.html
+++ b/index.html
@@ -205,6 +205,10 @@
         </li>
         <li>
           <a href=
+          "https://heycam.github.io/webidl/#notallowederror"><dfn><code>NotAllowedError</code></dfn></a>
+        </li>
+        <li>
+          <a href=
           "https://heycam.github.io/webidl/#idl-DOMException"><dfn><code>DOMException</code></dfn></a>
         </li>
         <li>
@@ -303,7 +307,7 @@
         <li>If this <a>Navigator</a> object's <a>relevant global object</a>'s
         <a>associated <code>Document</code></a> is not <a>allowed to use</a>
         the <code>battery</code> feature, then reject this <a>Navigator</a>
-        object's <a>battery promise</a> with a "<a>SecurityError</a>"
+        object's <a>battery promise</a> with a "<a>NotAllowedError</a>"
         <a>DOMException</a>, return this <a>Navigator</a> object's <a>battery
         promise</a> and abort these steps.
           <div class="note">

--- a/index.html
+++ b/index.html
@@ -135,8 +135,8 @@
         Terminology
       </h2>
       <p>
-        The following concepts, terms, and interfaces are defined in
-        [[!HTML]], [[!HTML5]], [[!ECMASCRIPT]], [[!WEBIDL]], and [[!SECURE-CONTEXTS]]:
+        The following concepts, terms, and interfaces are defined in [[!HTML]],
+        [[!HTML5]], [[!ECMASCRIPT]], [[!WEBIDL]], and [[!SECURE-CONTEXTS]]:
       </p>
       <ul>
         <li>
@@ -204,6 +204,21 @@
           "https://www.w3.org/TR/secure-contexts/#secure-context"><dfn>secure
           context</dfn></a>
         </li>
+        <li>
+          <a href=
+          "https://html.spec.whatwg.org/multipage/browsers.html#active-document">
+          <dfn>active document</dfn></a>
+        </li>
+        <li>
+          <a href=
+          "https://html.spec.whatwg.org/multipage/origin.html#concept-origin"><dfn>
+          origin</dfn></a>
+        </li>
+        <li>
+          <a href=
+          "https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain">
+          <dfn>same-origin domain</dfn></a>
+        </li>
       </ul>
     </section>
     <section class="informative">
@@ -261,11 +276,12 @@
         this <a>Navigator</a> object's <a>battery promise</a> and abort these
         steps.
         </li>
-        <li>If the <a>browsing context</a> is not a <a>top-level browsing
-        context</a>, then reject this <a>Navigator</a> object's <a>battery
-        promise</a> with a "<a>SecurityError</a>" <a>DOMException</a>, return
-        this <a>Navigator</a> object's <a>battery promise</a> and abort these
-        steps.
+        <li>If the <a>top-level browsing context</a>'s <a>active document</a>'s
+        <a>origin</a> and the <a>origin</a> specified by the <a>current
+        settings object</a> is not <a>same-origin domain</a>, then reject this
+        <a>Navigator</a> object's <a>battery promise</a> with a
+        "<a>SecurityError</a>" <a>DOMException</a>, return this <a>Navigator</a>
+        object's <a>battery promise</a> and abort these steps.
         </li>
         <li>If this <a>Navigator</a> object's <a>battery promise</a> is not
         <code>null</code>, return this <a>Navigator</a> object's <a>battery

--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
       </h2>
       <p>
         The following concepts, terms, and interfaces are defined in
-        [[!HTML5]], [[!ECMASCRIPT]], [[!WEBIDL]], and [[!SECURE-CONTEXTS]]:
+        [[!HTML]], [[!HTML5]], [[!ECMASCRIPT]], [[!WEBIDL]], and [[!SECURE-CONTEXTS]]:
       </p>
       <ul>
         <li>
@@ -180,8 +180,8 @@
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">
-          incumbent settings object</a></dfn>
+          "https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">
+          current settings object</a></dfn>
         </li>
         <li>
           <a href=
@@ -255,7 +255,7 @@
         the following steps:
       </p>
       <ol>
-        <li>If the <a>incumbent settings object</a> is not a <a>secure
+        <li>If the <a>current settings object</a> is not a <a>secure
         context</a>, then reject this <a>Navigator</a> object's <a>battery
         promise</a> with a "<a>SecurityError</a>" <a>DOMException</a>, return
         this <a>Navigator</a> object's <a>battery promise</a> and abort these

--- a/index.html
+++ b/index.html
@@ -311,7 +311,8 @@
             <code>Document</code></a>'s <a>browsing context</a>'s <a>active
             document</a>'s <a>origin</a> is not <a>same origin-domain</a> with
             the <a>origin</a> of the <a>current settings object</a> of this
-            <a>Navigator</a> object.
+            <a>Navigator</a> object, unless specifically allowed by the
+            document's feature policy.
           </div>
         </li>
         <li>If this <a>Navigator</a> object's <a>battery promise</a> is not

--- a/index.html
+++ b/index.html
@@ -142,47 +142,54 @@
       <ul>
         <li>
           <a href=
-          "https://www.w3.org/TR/html5/webappapis.html#navigator"><dfn><code>Navigator</code></dfn></a>
+          "https://html.spec.whatwg.org/#navigator"><dfn><code>Navigator</code></dfn></a>
         </li>
         <li>
           <a href=
-          "https://www.w3.org/TR/html5/webappapis.html#eventhandler"><dfn><code>
-          EventHandler</code></dfn></a>
+          "https://html.spec.whatwg.org/#eventhandler"><dfn><code>EventHandler</code></dfn></a>
         </li>
         <li>
-          <dfn><a href=
-          "https://www.w3.org/TR/html5/webappapis.html#queue-a-task">queue a
+          <dfn><a href="https://html.spec.whatwg.org/#queue-a-task">queue a
           task</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html5/webappapis.html#fire-a-simple-event">fires
-          a simple event</a></dfn>
+          "https://www.w3.org/TR/html5/webappapis.html#firing-a-simple-event-named-e">
+          fires a simple event</a></dfn>
         </li>
         <li>
-          <dfn><a href=
-          "https://www.w3.org/TR/html5/webappapis.html#event-handlers">event
+          <dfn><a href="https://html.spec.whatwg.org/#event-handlers">event
           handlers</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html5/webappapis.html#event-handler-event-type">
-          event handler event types</a></dfn>
+          "https://html.spec.whatwg.org/#event-handler-event-type">event
+          handler event types</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html5/browsers.html#browsing-context">browsing
+          "https://html.spec.whatwg.org/#browsing-context">browsing
           context</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html5/browsers.html#top-level-browsing-context">
-          top-level browsing context</a></dfn>
+          "https://html.spec.whatwg.org/#concept-relevant-global">relevant
+          global object</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">
-          current settings object</a></dfn>
+          "https://html.spec.whatwg.org/#relevant-settings-object">relevant
+          settings object</a></dfn>
+        </li>
+        <li>
+          <dfn><a href=
+          "https://html.spec.whatwg.org/#current-settings-object">current
+          settings object</a></dfn>
+        </li>
+        <li>
+          <dfn><a href=
+          "https://html.spec.whatwg.org/#concept-document-window">associated
+          <code>Document</code></a></dfn>
         </li>
         <li>
           <a href=
@@ -206,19 +213,16 @@
           context</dfn></a>
         </li>
         <li>
-          <a href=
-          "https://html.spec.whatwg.org/multipage/browsers.html#active-document">
-          <dfn>active document</dfn></a>
+          <a href="https://html.spec.whatwg.org/#active-document"><dfn>active
+          document</dfn></a>
         </li>
         <li>
           <a href=
-          "https://html.spec.whatwg.org/multipage/origin.html#concept-origin"><dfn>
-          origin</dfn></a>
+          "https://html.spec.whatwg.org/#concept-origin"><dfn>origin</dfn></a>
         </li>
         <li>
-          <a href=
-          "https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain">
-          <dfn>same-origin domain</dfn></a>
+          <a href="https://html.spec.whatwg.org/#same-origin-domain"><dfn>same
+          origin-domain</dfn></a>
         </li>
         <li>
           <a href=
@@ -286,18 +290,20 @@
         the following steps:
       </p>
       <ol>
-        <li>If the <a>current settings object</a> is not a <a>secure
-        context</a>, then reject this <a>Navigator</a> object's <a>battery
-        promise</a> with a "<a>SecurityError</a>" <a>DOMException</a>, return
-        this <a>Navigator</a> object's <a>battery promise</a> and abort these
-        steps.
-        </li>
-        <li>If the <a>top-level browsing context</a>'s <a>active document</a>'s
-        <a>origin</a> and the <a>origin</a> specified by the <a>current
-        settings object</a> is not <a>same-origin domain</a>, then reject this
+        <li>If the <a>relevant settings object</a> of this <a>Navigator</a>
+        object is not a <a>secure context</a>, then reject this
         <a>Navigator</a> object's <a>battery promise</a> with a
-        "<a>SecurityError</a>" <a>DOMException</a>, return this <a>Navigator</a>
-        object's <a>battery promise</a> and abort these steps.
+        "<a>SecurityError</a>" <a>DOMException</a>, return this
+        <a>Navigator</a> object's <a>battery promise</a> and abort these steps.
+        </li>
+        <li>If this <a>Navigator</a> object's <a>relevant global object</a>'s
+        <a>associated <code>Document</code></a>'s <a>browsing context</a>'s <a>
+          active document</a>'s <a>origin</a> is not <a>same origin-domain</a>
+          with the <a>origin</a> of the <a>current settings object</a> of this
+          <a>Navigator</a> object, then reject this <a>Navigator</a> object's
+          <a>battery promise</a> with a "<a>SecurityError</a>"
+          <a>DOMException</a>, return this <a>Navigator</a> object's <a>battery
+          promise</a> and abort these steps.
         </li>
         <li>If this <a>Navigator</a> object's <a>battery promise</a> is not
         <code>null</code>, return this <a>Navigator</a> object's <a>battery
@@ -523,9 +529,9 @@
         The Battery Status API is a <a>policy-controlled feature</a>, as
         defined by Feature Policy [[!FEATURE-POLICY]]. The <a>feature name</a>
         for the Battery Status API is "<code>battery</code>". The <a>default
-        allowlist</a> for the Battery Status API is <code>["self"]</code>. When
-        disabled in a document, the <code><a>getBattery</a>()</code> method
-        MUST return a <a>promise</a> which rejects with a
+        allowlist</a> for the Battery Status API is <code>« "self" »</code>.
+        When disabled in a document, the <code><a>getBattery</a>()</code>
+        method MUST return a <a>promise</a> which rejects with a
         "<a>SecurityError</a>" <a>DOMException</a>.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -148,11 +148,6 @@
           EventHandler</code></dfn></a>
         </li>
         <li>
-          <a href=
-          "https://dom.spec.whatwg.org/#eventtarget"><dfn><code>
-          EventTarget</code></dfn></a>
-        </li>
-        <li>
           <dfn><a href=
           "https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a
           task</a></dfn>


### PR DESCRIPTION
Per @clelland's suggestion in https://github.com/w3c/battery/issues/10#issuecomment-324661401 this change allows Battery Status API use in same-origin children, and adds Feature Policy integration.

PTAL @clelland @RByers @mounirlamouri @riju

Fixes #10.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/battery/pull/13.html" title="Last updated on Sep 24, 2019, 12:29 PM UTC (6d2ce77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/13/ce5317b...6d2ce77.html" title="Last updated on Sep 24, 2019, 12:29 PM UTC (6d2ce77)">Diff</a>