### PR TITLE
Adopt 'test as you commit' policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,12 @@ contributors in the pull request's body or in subsequent comments.
 
  If you are making a pull request on behalf of someone else but you had no part in designing the 
  feature, you can remove yourself with the above syntax.
+
+# Tests
+
+For normative changes, a corresponding
+[web-platform-tests](https://github.com/w3c/web-platform-tests) PR is highly appreciated. Typically,
+both PRs will be merged at the same time. Note that a test change that contradicts the spec should
+not be merged before the corresponding spec change. If testing is not practical, please explain why
+and if appropriate [file a web-platform-tests issue](https://github.com/w3c/web-platform-tests/issues/new)
+to follow up later. Add the `type:untestable` or `type:missing-coverage` label as appropriate.


### PR DESCRIPTION
We started down this path in https://github.com/w3c/battery/pull/13 and https://github.com/w3c/web-platform-tests/pull/7944 so let's add this boilerplate to make this best practice more official.

This is to match the expected global WG policy proposed for the new charter:
https://w3c.github.io/dap-charter/DeviceAPICharter.html#deliverables

Cc @foolip @Honry to review before merge (as a practicality, I guess you won't object).