### PR TITLE
Remove processVersion

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,6 @@
           testSuiteURI: "https://w3c-test.org/battery-status/",
           implementationReportURI: "https://w3c.github.io/test-results/battery-status/20160621.html",
           scheme:       "https",
-          processVersion: 2005,
           otherLinks: [{
             key: "Participate",
             data: [


### PR DESCRIPTION
`processVersion` was [removed](https://github.com/w3c/respec/wiki/processVersion) from ReSpec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/battery/pull/20.html" title="Last updated on Jun 11, 2019, 8:54 AM UTC (b600860)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/20/198372c...b600860.html" title="Last updated on Jun 11, 2019, 8:54 AM UTC (b600860)">Diff</a>