### PR TITLE
Add EventTarget definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,6 +148,11 @@
           EventHandler</code></dfn></a>
         </li>
         <li>
+          <a href=
+          "https://dom.spec.whatwg.org/#eventtarget"><dfn><code>
+          EventTarget</code></dfn></a>
+        </li>
+        <li>
           <dfn><a href=
           "https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a
           task</a></dfn>


### PR DESCRIPTION
Fix ReSpec error:

>Couldn't match "EventTarget" to anything in the document or to any other spec. Please provide a data-cite attribute for it. at: 1.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/battery/pull/22.html" title="Last updated on Jun 26, 2019, 6:26 PM UTC (e3f575b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/22/d63eb82...e3f575b.html" title="Last updated on Jun 26, 2019, 6:26 PM UTC (e3f575b)">Diff</a>