### PR TITLE
Replace SecurityError with NotAllowedError in feature policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,7 +557,7 @@
         by the string "<code>battery</code>". It's default allowlist is
         <code>'self'</code>. When disabled in a document, the
         <code><a>getBattery</a>()</code> method MUST return a <a>promise</a>
-        which rejects with a "<a>SecurityError</a>" <a>DOMException</a>.
+        which rejects with a "<a>NotAllowedError</a>" <a>DOMException</a>.
       </p>
     </section>
     <section class="informative">


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Honry/battery/pull/24.html" title="Last updated on Sep 25, 2019, 12:05 PM UTC (c8e83cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/24/5a628d9...Honry:c8e83cf.html" title="Last updated on Sep 25, 2019, 12:05 PM UTC (c8e83cf)">Diff</a>