### PR TITLE
Migrate from respec-w3c-common to respec-w3c

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,12 @@
       Battery Status API
     </title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class=
-    'remove'>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     </script>
     <script class="remove">
       var respecConfig = {
           specStatus:           "ED",
           shortName:            "battery-status",
-          //publishDate:        "2016-03-29",
           previousPublishDate:  "2014-12-09",
           previousMaturity:     "CR",
           edDraftURI:           "https://w3c.github.io/battery/",
@@ -22,16 +20,10 @@
               { name: "Anssi Kostiainen", company: "Intel", companyURL: "http://intel.com/" },
               { name: "Mounir Lamouri", company: "Google Inc.", companyURL: "https://google.com/", note: "previously Mozilla" }
           ],
-          inlineCSS:    true,
-          noIDLIn:      true,
-          noLegacyStyle: true,
-          wg:           "Device and Sensors Working Group",
-          wgURI:        "https://www.w3.org/2009/dap/",
+          group:        "das",
           wgPublicList: "public-device-apis",
-          wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/43696/status",
           testSuiteURI: "https://w3c-test.org/battery-status/",
           implementationReportURI: "https://w3c.github.io/test-results/battery-status/20160621.html",
-          scheme:       "https",
           otherLinks: [{
             key: "Participate",
             data: [


### PR DESCRIPTION
- Modernize configuration options

https://github.com/w3c/respec/wiki/respec-w3c-common-migration-guide


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/battery/pull/31.html" title="Last updated on Mar 1, 2021, 2:08 PM UTC (edbd3f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/31/38e5c50...edbd3f9.html" title="Last updated on Mar 1, 2021, 2:08 PM UTC (edbd3f9)">Diff</a>