### PR TITLE
Chore: update the SoTD

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,13 +64,12 @@
     </section>
     <section id="sotd">
       <p>
-        The Devices and Sensors Working Group is pursuing modern security and
-        privacy reviews for this specification in consideration of the amount of
-        change in both this specification and in privacy and security review
-        practices since the horizontal reviews took place. Similarly, the group
-        is pursuing an update to the Technical Architecture Group review for
-        this specification to account for the latest architectural review
-        practices.
+        The Devices and Sensors Working Group will apply editorial
+        modernizations to this specification, perform a round of self-review and
+        revisions on the security and privacy aspects of the API before
+        requesting horizontal review. Existing security and privacy issues can
+        be found <a
+        href="https://www.w3.org/PM/horizontal/review.html?shortname=battery-status">here</a>.
       </p>
     </section>
     <section class="informative">


### PR DESCRIPTION
Because we haven't requested wide review for this spec, the description here ("since the horizontal reviews took place" and "an update to the Technical Architecture Group review") is not accurate, so I updated the SoTD per https://www.w3.org/2021/04/07-dap-minutes.html#r02


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/battery/pull/37.html" title="Last updated on Aug 13, 2021, 2:59 AM UTC (3f202d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/37/7d59f61...3f202d6.html" title="Last updated on Aug 13, 2021, 2:59 AM UTC (3f202d6)">Diff</a>