### PR TITLE
Chore: update the SoTD

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,9 +67,9 @@
         The Devices and Sensors Working Group will apply editorial
         modernizations to this specification, perform a round of self-review and
         revisions on the security and privacy aspects of the API before
-        requesting horizontal review. Existing security and privacy issues can
-        be found <a
-        href="https://www.w3.org/PM/horizontal/review.html?shortname=battery-status">here</a>.
+        requesting horizontal review. Existing <a
+        href="https://www.w3.org/PM/horizontal/review.html?shortname=battery-status">security
+        and privacy issues</a> are available.
       </p>
     </section>
     <section class="informative">


### PR DESCRIPTION
Tweak the link text so that it's easier for visually-impaired users to use their screen readers to scan for links.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/battery/pull/38.html" title="Last updated on Aug 17, 2021, 6:50 AM UTC (383fa29)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/38/8112cb1...383fa29.html" title="Last updated on Aug 17, 2021, 6:50 AM UTC (383fa29)">Diff</a>