### PR TITLE
chore: Reformat index.html and run tidy on pull requests

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -1,0 +1,30 @@
+name: Run tidy on spec
+on:
+  push:
+    branches:
+      - "gh-pages"
+    paths:
+      - "index.html"
+
+jobs:
+  tidy:
+    name: Reformat index.html if necessary
+    # We need macos-latest because tidy-2:5.6.0 which is present on all Ubuntu
+    # releases supported by GitHub actions has a bug that causes the documents
+    # to be wrongly formatted.
+    # https://github.com/w3c/screen-wake-lock/pull/319 has more details.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: brew install tidy-html5
+      - run: tidy -config tidyrc -modify index.html
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          body: |
+            Automated change.
+
+            `index.html` reformatted with `tidy -config tidyrc -modify index.html`.
+          branch: html-tidy
+          commit-message: "chore: Reformat document using tidy-html5"
+          delete-branch: true
+          title: "chore(tidy): reformat index.html"

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
       Battery Status API
     </title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"
+    defer></script>
     <script class="remove">
       var respecConfig = {
           specStatus:           "ED",
@@ -71,11 +72,11 @@
     <section id="sotd">
       <p>
         The Devices and Sensors Working Group will apply editorial
-        modernizations to this specification, perform a round of self-review and
-        revisions on the security and privacy aspects of the API before
-        requesting horizontal review. Existing <a
-        href="https://www.w3.org/PM/horizontal/review.html?shortname=battery-status">security
-        and privacy issues</a> are available.
+        modernizations to this specification, perform a round of self-review
+        and revisions on the security and privacy aspects of the API before
+        requesting horizontal review. Existing <a href=
+        "https://www.w3.org/PM/horizontal/review.html?shortname=battery-status">
+        security and privacy issues</a> are available.
       </p>
     </section>
     <section class="informative">
@@ -168,13 +169,13 @@
       <p>
         For each {{Navigator}} object, there is a <dfn>battery promise</dfn>,
         which is a {{Promise}} created in the {{Navigator}} object's
-        <a>relevant realm</a>. There is also a <dfn>battery manager</dfn>, which
-        is initially null.
+        <a>relevant realm</a>. There is also a <dfn>battery manager</dfn>,
+        which is initially null.
       </p>
       <p class="warning">
         This method is not currently restricted to a <a>secure context</a>, but
-        it should be. Track progress on that in <a
-        href="https://github.com/w3c/battery/issues/15">issue #15</a>.
+        it should be. Track progress on that in <a href=
+        "https://github.com/w3c/battery/issues/15">issue #15</a>.
       </p>
       <p>
         The <code id=
@@ -182,32 +183,33 @@
         "Navigator">getBattery</dfn>()</code> method steps are:
       </p>
       <ol>
-        <li>
-          If <a>this</a>'s <a>relevant global object</a>'s <a>associated
-          <code>Document</code></a> is not <a>allowed to use</a> the
-          "<code>battery</code>" feature, then reject <a>this</a>'s <a>battery
-          promise</a> with a {{"NotAllowedError"}} {{DOMException}}, and
-          return <a>this</a>'s <a>battery promise</a>.
-
-          <div class="note">In other words, this step rejects if the
-          <a>associated <code>Document</code></a>'s <a>browsing context</a>'s
-          <a>active document</a>'s <a>origin</a> is not <a>same
-          origin-domain</a> with the <a>origin</a> of the <a>current settings
-          object</a> of this {{Navigator}} object, unless specifically
-          allowed by the document's permissions policy.</div>
+        <li>If <a>this</a>'s <a>relevant global object</a>'s <a>associated
+        <code>Document</code></a> is not <a>allowed to use</a> the
+        "<code>battery</code>" feature, then reject <a>this</a>'s <a>battery
+        promise</a> with a {{"NotAllowedError"}} {{DOMException}}, and return
+        <a>this</a>'s <a>battery promise</a>.
+          <div class="note">
+            In other words, this step rejects if the <a>associated
+            <code>Document</code></a>'s <a>browsing context</a>'s <a>active
+            document</a>'s <a>origin</a> is not <a>same origin-domain</a> with
+            the <a>origin</a> of the <a>current settings object</a> of this
+            {{Navigator}} object, unless specifically allowed by the document's
+            permissions policy.
+          </div>
         </li>
-
         <li>If <a>this</a>'s <a>battery manager</a> is not null, return
-        <a>this</a>'s <a>battery promise</a>.</li>
-
+        <a>this</a>'s <a>battery promise</a>.
+        </li>
         <li>Set <a>this</a>'s <a>battery manager</a> to the result of
         <a>creating a new <code>BatteryManager</code> object</a> in
-        <a>this</a>'s <a>relevant realm</a>.</li>
-
-        <li><a>Resolve</a> <a>this</a>'s <a>battery promise</a> with
-        <a>this</a>'s <a>battery manager</a>.</li>
-
-        <li>Return <a>this</a>'s <a>battery promise</a>.</li>
+        <a>this</a>'s <a>relevant realm</a>.
+        </li>
+        <li>
+          <a>Resolve</a> <a>this</a>'s <a>battery promise</a> with
+          <a>this</a>'s <a>battery manager</a>.
+        </li>
+        <li>Return <a>this</a>'s <a>battery promise</a>.
+        </li>
       </ol>
     </section>
     <section>
@@ -242,16 +244,17 @@
         };
       </pre>
       <p>
-        When the <a>user agent</a> is to <dfn data-lt="creating a new
-        BatteryManager object">create a new <code>BatteryManager</code>
-        object</dfn>, it MUST instantiate a new <a>BatteryManager</a> object and
-        set its attributes' values to those that represent the <a>current
-        battery status information</a>, unless the <a>user agent</a> is
-        <a>unable to report the battery status information</a>, in which case
-        the values MUST be set to <dfn>default values</dfn> as follows:
-        <code>charging</code> MUST be set to true, <code>chargingTime</code>
-        MUST be set to 0, <code>dischargingTime</code> MUST be set to positive
-        Infinity, and <code>level</code> MUST be set to 1.0.
+        When the <a>user agent</a> is to <dfn data-lt=
+        "creating a new BatteryManager object">create a new
+        <code>BatteryManager</code> object</dfn>, it MUST instantiate a new
+        <a>BatteryManager</a> object and set its attributes' values to those
+        that represent the <a>current battery status information</a>, unless
+        the <a>user agent</a> is <a>unable to report the battery status
+        information</a>, in which case the values MUST be set to <dfn>default
+        values</dfn> as follows: <code>charging</code> MUST be set to true,
+        <code>chargingTime</code> MUST be set to 0,
+        <code>dischargingTime</code> MUST be set to positive Infinity, and
+        <code>level</code> MUST be set to 1.0.
       </p>
       <p>
         The <a>user agent</a> is said to be <dfn>unable to report the battery
@@ -282,7 +285,8 @@
         the battery is discharging, the implementation is unable to report the
         remaining charging time, or otherwise. When the battery charging time
         is updated, the <a>user agent</a> MUST <a>queue a task</a> which sets
-        the <code>chargingTime</code> attribute's value and <a>fires an event</a> named <code><a>chargingtimechange</a></code> at the
+        the <code>chargingTime</code> attribute's value and <a>fires an
+        event</a> named <code><a>chargingtimechange</a></code> at the
         <a>BatteryManager</a> object.
       </p>
       <p>
@@ -304,8 +308,8 @@
         unable to report the battery's level, or there is no battery attached
         to the system. When the battery level is updated, the <a>user agent</a>
         MUST <a>queue a task</a> which sets the <code>level</code> attribute's
-        value and <a>fires an event</a> named
-        <code><a>levelchange</a></code> at the <a>BatteryManager</a> object.
+        value and <a>fires an event</a> named <code><a>levelchange</a></code>
+        at the <a>BatteryManager</a> object.
       </p>
       <p class="note">
         The definition of how often the <code><a>chargingtimechange</a></code>,

--- a/tidyrc
+++ b/tidyrc
@@ -1,0 +1,4 @@
+char-encoding: utf8
+indent: yes
+wrap: 80
+tidy-mark: no


### PR DESCRIPTION
* The first commit reformats `index.html` to have a baseline for future commits.
* The second commit adds a GitHub action that runs `tidy` when a new commit is pushed and automatically creates a PR with the reformatted file when necessary.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/battery/pull/41.html" title="Last updated on Aug 25, 2021, 7:16 PM UTC (49fa684)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/41/ae3cd7d...rakuco:49fa684.html" title="Last updated on Aug 25, 2021, 7:16 PM UTC (49fa684)">Diff</a>