### PR TITLE
editorial: Remove reference to getBattery() from Permissions Policy section

### DIFF
--- a/index.html
+++ b/index.html
@@ -411,9 +411,7 @@
       <p data-link-for="Navigator">
         The Battery Status API is a <a>policy-controlled feature</a> identified
         by the string "<code>battery</code>". Its <a>default allowlist</a> is
-        <code>'self'</code>. When disabled in a document, the
-        <code><a>getBattery</a>()</code> method will return a {{Promise}} which
-        rejects with a {{"NotAllowedError"}} {{DOMException}}.
+        <code>'self'</code>.
       </p>
     </section>
     <section class="informative">


### PR DESCRIPTION
This bit is already defined in the `getBattery()` algorithm, and having it
here again only makes us have to update the text in two different locations
if anything changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/battery/pull/42.html" title="Last updated on Aug 26, 2021, 7:30 AM UTC (96e2735)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/42/ae3cd7d...rakuco:96e2735.html" title="Last updated on Aug 26, 2021, 7:30 AM UTC (96e2735)">Diff</a>