### PR TITLE
editorial: Remove Web IDL paragraph from Conformance section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,12 +112,6 @@
         product: the <dfn>user agent</dfn> that implements the interfaces that
         it contains.
       </p>
-      <p>
-        Implementations that use ECMAScript to implement the APIs defined in
-        this specification must implement them in a manner consistent with the
-        ECMAScript Bindings defined in the Web IDL specification [[!WEBIDL]],
-        as this specification uses that specification and terminology.
-      </p>
     </section>
     <section>
       <h2>


### PR DESCRIPTION
This was added more than 10 years ago, and at this point it sounds very
redundant.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/battery/pull/44.html" title="Last updated on Aug 27, 2021, 8:51 AM UTC (ce6e5d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/44/92ecfcf...rakuco:ce6e5d3.html" title="Last updated on Aug 27, 2021, 8:51 AM UTC (ce6e5d3)">Diff</a>