### PR TITLE
editorial: Use Web IDL's definition conventions for methods and getters.

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,8 +217,7 @@
         </h3>
         <p data-tests=
         "battery-promise-window.https.html, battery-promise.https.html">
-          The <dfn>getBattery()</dfn> method, when invoked, MUST run the
-          following steps:
+          The <dfn>getBattery()</dfn> method steps are:
         </p>
         <ol class="algorithm">
           <li>If [=this=].{{Navigator/[[BatteryPromise]]}} is `null`, then set
@@ -430,8 +429,8 @@
           The `charging` attribute
         </h3>
         <p>
-          The <dfn>charging</dfn> attribute's getter returns the value of the
-          {{BatteryManager/[[Charging]]}} internal slot.
+          The <dfn>charging</dfn> getter steps are to return
+          [=this=].{{BatteryManager/[[Charging]]}}.
         </p>
       </section>
       <section>
@@ -439,8 +438,8 @@
           The `chargingTime` attribute
         </h3>
         <p>
-          The <dfn>chargingTime</dfn> attribute's getter returns the value of
-          the {{BatteryManager/[[ChargingTime]]}} internal slot.
+          The <dfn>chargingTime</dfn> getter steps are to return
+          [=this=].{{BatteryManager/[[ChargingTime]]}}.
         </p>
       </section>
       <section>
@@ -448,8 +447,8 @@
           The `dischargingTime` attribute
         </h3>
         <p>
-          The <dfn>dischargingTime</dfn> attribute's getter returns the value
-          of the {{BatteryManager/[[DischargingTime]]}} internal slot.
+          The <dfn>dischargingTime</dfn> getter steps are to return
+          [=this=].{{BatteryManager/[[DischargingTime]]}}.
         </p>
       </section>
       <section>
@@ -457,8 +456,8 @@
           The `level` attribute
         </h3>
         <p>
-          The <dfn>level</dfn> attribute's getter returns the value of the
-          {{BatteryManager/[[Level]]}} internal slot.
+          The <dfn>level</dfn> getter steps are to return
+          [=this=].{{BatteryManager/[[Level]]}}.
         </p>
       </section>
       <section>


### PR DESCRIPTION
Aligns with whatwg/webidl#882:
- Describe getters as "The attr getter steps are [...]".
- Describe methods as "The myMethod(arg) method steps are [...]".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/battery/pull/49.html" title="Last updated on Nov 5, 2021, 12:54 PM UTC (c4d9c73)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/49/4291db6...rakuco:c4d9c73.html" title="Last updated on Nov 5, 2021, 12:54 PM UTC (c4d9c73)">Diff</a>