### PR TITLE
Set respecConfig.github

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
           // publishDate: "2021-06-01",
           previousPublishDate:  "2021-06-01",
           previousMaturity:     "WD",
-          edDraftURI:           "https://w3c.github.io/battery/",
+          github:               "w3c/battery",
           editors:  [
               {
                 name: "Anssi Kostiainen",
@@ -34,27 +34,6 @@
           wgPublicList: "public-device-apis",
           testSuiteURI: "https://wpt.live/battery-status/",
           implementationReportURI: "https://w3c.github.io/test-results/battery-status/20160621.html",
-          otherLinks: [{
-            key: "Participate",
-            data: [
-              {
-                value: "public-device-apis@w3.org",
-                href: "https://lists.w3.org/Archives/Public/public-device-apis/"
-              },
-              {
-                value: "GitHub w3c/battery",
-                href: "https://github.com/w3c/battery/"
-              },
-              {
-                value: "GitHub w3c/battery/issues",
-                href: "https://github.com/w3c/battery/issues"
-              },
-              {
-                value: "GitHub w3c/battery/commits",
-                href: "https://github.com/w3c/battery/commits/"
-              }
-            ]
-          }],
           xref: {
             profile: "web-platform",
             specs: [


### PR DESCRIPTION
This takes care of setting `edDraftURI` as well as adding links to the
GitHub repository in the "Feedback" section, which allows us to simplify
respecConfig a bit.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/battery/pull/50.html" title="Last updated on Nov 5, 2021, 3:54 PM UTC (a16604a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/50/d43d6bb...rakuco:a16604a.html" title="Last updated on Nov 5, 2021, 3:54 PM UTC (a16604a)">Diff</a>