### PR TITLE
Add [SecureContext] to BatteryManager and the Navigator partial interface.

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,14 +135,14 @@
         Extensions to the `Navigator` interface
       </h2>
       <pre class="idl">
+        [SecureContext]
         partial interface Navigator {
           Promise&lt;BatteryManager&gt; getBattery();
         };
       </pre>
-      <p class="warning">
-        This method is not currently restricted to a <a>secure context</a>, but
-        it should be. Track progress on that in <a href=
-        "https://github.com/w3c/battery/issues/15">issue #15</a>.
+      <p class="note">
+        This method was exposed to a non-secure context until <a href=
+        "https://github.com/w3c/battery/pull/51">PR #51</a>.
       </p>
       <section>
         <h3>
@@ -236,7 +236,7 @@
         The `BatteryManager` interface
       </h2>
       <pre class="idl">
-        [Exposed=Window]
+        [SecureContext, Exposed=Window]
         interface BatteryManager : EventTarget {
             readonly        attribute boolean             charging;
             readonly        attribute unrestricted double chargingTime;


### PR DESCRIPTION
In other words, stop exposing this API to insecure origins. Even though this
API is not new, it provides user information that, transmitted insecurely,
can pose a risk to user privacy. See
https://w3ctag.github.io/design-principles/#secure-context for more
information on the guidelines we are trying to follow.

This has been discussed since at least 2016 (see #5). #11 made access from
an insecure origin throw a SecurityError at a time when the
`[SecureContext]` Web IDL extended attribute was not widespread.
Unfortunately, the spec change was not accompanied by a change in the
implementation(s) and, to this day, Blink's implementation (the only
remaining one) continues to expose the API to insecure origins.

Years later, #30 was added in the context of the discussions in #15 where it
was noted that the spec was still manually throwing a SecurityError when
checking if it was called by a secure origin. Besides stopping throwing a
SecurityError (which was never implemented), #30 also recognized the current
situation by noting that the API _should_ use `[SecureContext]` but did not
because it only made sense to do so when the implementation was updated
accordingly.

This change finally adds `[SecureContext]` to the spec's Web IDL because I
am also handling the Blink implementation [1][2]: starting with Chrome 99,
users will be warned that using the Battery Status API in an insecure origin
is deprecated, and starting with Chrome 103 doing so will no longer be
possible.

[1] https://chromestatus.com/feature/4878376799043584
[2] https://groups.google.com/a/chromium.org/g/blink-dev/c/w80tJL8uEV8/m/PfrHlvtgAgAJ

From a testing perspective, there isn't much to be done:
- web-platform-tests/wpt#5871 changed the existing tests to run in HTTPS.
- web-platform-tests/wpt#32556 removed the test for the SecurityError
  exception that never passed.

Fixes #15


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/battery/pull/51.html" title="Last updated on Feb 1, 2022, 8:54 AM UTC (c706ad9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/51/b451e98...c706ad9.html" title="Last updated on Feb 1, 2022, 8:54 AM UTC (c706ad9)">Diff</a>