### PR TITLE
editorial: Remove permissions policy-related note in getBattery()

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,13 +213,6 @@
           [=policy-controlled feature=], then [=reject=]
           [=this=].{{Navigator/[[BatteryPromise]]}} with a
           {{"NotAllowedError"}} {{DOMException}}.
-            <div class="note">
-              In other words, this step rejects if the [=associated
-              `Document`=]'s [=browsing context=]'s [=active document=]'s
-              [=origin=] is not [=same origin-domain=] with the [=origin=] of
-              the [=current settings object=] of this {{Navigator}} object,
-              unless specifically allowed by the document's permissions policy.
-            </div>
           </li>
           <li>Otherwise:
             <ol>


### PR DESCRIPTION
Not only does this fix a ReSpec error caused by the fact that the "active
document" dfn no longer exists, but the note was also factually incorrect:
the "allowed to use" algorithm is not equal to checking if two origins are
same origin-domain with each other.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/battery/pull/59.html" title="Last updated on Jan 5, 2024, 10:09 AM UTC (450080b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/59/86d16a7...450080b.html" title="Last updated on Jan 5, 2024, 10:09 AM UTC (450080b)">Diff</a>