### PR TITLE
editorial: Adjust references in Permissions Policy section

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,10 +568,10 @@
       <h2>
         Permissions Policy integration
       </h2>
-      <p data-link-for="Navigator">
+      <p>
         The Battery Status API is a <a>policy-controlled feature</a> identified
-        by the string "<code>battery</code>". Its <a>default allowlist</a> is
-        <code>'self'</code>.
+        by the string "<code>battery</code>". Its [=policy-controlled feature/default allowlist=]
+        is <code>[=default allowlist/'self'=]</code>.
       </p>
     </section>
     <section class="informative">


### PR DESCRIPTION
* Remove `data-link-for="Navigator"`, unneeded since #42.
* Fix reference to "default allowlist", which has needed the
  "policy-controlled feature" scope since
  w3c/webappsec-permissions-policy#498. I could not get it to work using the
  `<a>` syntax with ReSpec though.
* While here, make "self" a reference to the corresponding term in the
  Permissions Policy spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/battery/pull/60.html" title="Last updated on Jan 5, 2024, 10:09 AM UTC (28befe2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/battery/60/86d16a7...28befe2.html" title="Last updated on Jan 5, 2024, 10:09 AM UTC (28befe2)">Diff</a>