### PR TITLE
editorial: Fix ReSpec errors to make CI pass again

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,13 +213,6 @@
           [=policy-controlled feature=], then [=reject=]
           [=this=].{{Navigator/[[BatteryPromise]]}} with a
           {{"NotAllowedError"}} {{DOMException}}.
-            <div class="note">
-              In other words, this step rejects if the [=associated
-              `Document`=]'s [=browsing context=]'s [=active document=]'s
-              [=origin=] is not [=same origin-domain=] with the [=origin=] of
-              the [=current settings object=] of this {{Navigator}} object,
-              unless specifically allowed by the document's permissions policy.
-            </div>
           </li>
           <li>Otherwise:
             <ol>

--- a/index.html
+++ b/index.html
@@ -561,10 +561,10 @@
       <h2>
         Permissions Policy integration
       </h2>
-      <p data-link-for="Navigator">
+      <p>
         The Battery Status API is a <a>policy-controlled feature</a> identified
-        by the string "<code>battery</code>". Its <a>default allowlist</a> is
-        <code>'self'</code>.
+        by the string "<code>battery</code>". Its [=policy-controlled feature/default allowlist=]
+        is <code>[=default allowlist/'self'=]</code>.
       </p>
     </section>
     <section class="informative">


### PR DESCRIPTION
This PR includes two commits adjusting the permissions policy integration text to fix CI.

---

editorial: Remove permissions policy-related note in getBattery()

Not only does this fix a ReSpec error caused by the fact that the "active
document" dfn no longer exists, but the note was also factually incorrect:
the "allowed to use" algorithm is not equal to checking if two origins are
same origin-domain with each other.

---

editorial: Adjust references in Permissions Policy section

* Remove `data-link-for="Navigator"`, unneeded since #42.
* Fix reference to "default allowlist", which has needed the
  "policy-controlled feature" scope since
  w3c/webappsec-permissions-policy#498. I could not get it to work using the
  `<a>` syntax with ReSpec though.
* While here, make "self" a reference to the corresponding term in the
  Permissions Policy spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 5, 2024, 10:14 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fbattery%2F153b3defe72eb45159f5fd8f7c29b74df3343796%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/gOuqjm/index.html?isPreview=true%3FisPreview%3Dtrue&publishDate=2024-01-05
ReSpec version: 34.3.0
File a bug: https://github.com/w3c/respec/
Error: undefined

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/battery%2361.)._
</details>
